### PR TITLE
Fix: pool asset0/asset1 order

### DIFF
--- a/src/MaglevBase.sol
+++ b/src/MaglevBase.sol
@@ -31,16 +31,18 @@ abstract contract MaglevBase is IMaglevBase, EVCUtil, Ownable {
 
     struct BaseParams {
         address evc;
-        address vault0;
-        address vault1;
+        address vaultA;
+        address vaultB;
         address myAccount;
     }
 
     constructor(BaseParams memory params) EVCUtil(params.evc) Ownable(msg.sender) {
-        vault0 = params.vault0;
-        vault1 = params.vault1;
-        asset0 = IEVault(vault0).asset();
-        asset1 = IEVault(vault1).asset();
+        address assetA = IEVault(params.vaultA).asset();
+        address assetB = IEVault(params.vaultB).asset();
+
+        (vault0, asset0, vault1, asset1) = assetA < assetB
+            ? (params.vaultA, assetA, params.vaultB, assetB)
+            : (params.vaultB, assetB, params.vaultA, assetA);
         myAccount = params.myAccount;
     }
 

--- a/test/EulerSwap.t.sol
+++ b/test/EulerSwap.t.sol
@@ -31,6 +31,8 @@ contract EulerSwapTest is MaglevTestBase {
 
         vm.prank(owner);
         maglev.setDebtLimit(50e18, 50e18);
+
+        assertTrue(maglev.asset0() < maglev.asset1());
     }
 
     function test_basicSwap_exactIn() public monotonicHolderNAV {

--- a/test/MaglevTestBase.t.sol
+++ b/test/MaglevTestBase.t.sol
@@ -44,7 +44,7 @@ contract MaglevTestBase is EVaultTestBase {
 
     function _getMaglevBaseParams() internal view returns (MaglevBase.BaseParams memory) {
         return
-            MaglevBase.BaseParams({evc: address(evc), vault0: address(eTST), vault1: address(eTST2), myAccount: holder});
+            MaglevBase.BaseParams({evc: address(evc), vaultA: address(eTST), vaultB: address(eTST2), myAccount: holder});
     }
 
     function _mintAndDeposit(address who, IEVault vault, uint256 amount) internal {


### PR DESCRIPTION
**Merge onyl after #2**

Previously the `asset0` and `asset1` stored in the pool are based on user inputs, with no address comparison a la Uniswap V2/V3 style. 

This PR renames the user inputs to `vaultA` and `vaultB`, and stores the vaults and assets addresses in `0` or `1` based on the actual assets order.