### PR TITLE
chore: rename EulerSwapTest to MaglevTest

### DIFF
--- a/test/MaglevTest.t.sol
+++ b/test/MaglevTest.t.sol
@@ -10,7 +10,7 @@ import {MaglevTestBase} from "./MaglevTestBase.t.sol";
 
 import {Maglev} from "../src/Maglev.sol";
 
-contract EulerSwapTest is MaglevTestBase {
+contract MaglevTest is MaglevTestBase {
     Maglev public maglev;
 
     function setUp() public virtual override {


### PR DESCRIPTION
Just thought as we are not using "EulerSwap" naming anywhere. Up to u @hoytech.