### PR TITLE
Limits PR review

### DIFF
--- a/src/EulerSwapPeriphery.sol
+++ b/src/EulerSwapPeriphery.sol
@@ -57,11 +57,7 @@ contract EulerSwapPeriphery is IEulerSwapPeriphery {
     }
 
     /// @inheritdoc IEulerSwapPeriphery
-    function getLimits(address eulerSwap, address tokenIn, address tokenOut)
-        external
-        view
-        returns (uint256 inLimit, uint256 outLimit)
-    {
+    function getLimits(address eulerSwap, address tokenIn, address tokenOut) external view returns (uint256, uint256) {
         if (
             !IEVC(IEulerSwap(eulerSwap).EVC()).isAccountOperatorAuthorized(
                 IEulerSwap(eulerSwap).eulerAccount(), eulerSwap

--- a/src/interfaces/IEulerSwapPeriphery.sol
+++ b/src/interfaces/IEulerSwapPeriphery.sol
@@ -23,10 +23,7 @@ interface IEulerSwapPeriphery {
         returns (uint256);
 
     /// @notice Max amount the pool can buy of tokenIn and sell of tokenOut
-    function getLimits(address eulerSwap, address tokenIn, address tokenOut)
-        external
-        view
-        returns (uint256 inLimit, uint256 outLimit);
+    function getLimits(address eulerSwap, address tokenIn, address tokenOut) external view returns (uint256, uint256);
 
     /**
      * @notice Computes the inverse of the `f()` function for the EulerSwap liquidity curve.


### PR DESCRIPTION
- Refactor `isAccountOperatorAuthorized()` calls.
- Refactor `eulerAccount()` calls.
- Refactor `vault0()/vault1()` calls.
- Add natspec, add functions to interface & re-order functions to follow current order.

```
- getLimits():
 - Original: 94,742 gas (avg)
 - Optimized: 93,006 gas (avg)
- quoteExactInput():
 - Original: 222,802 gas (avg)
 - Optimized: 216,741 gas (avg)
- quoteExactOutput():
 -  Original: 197,764 gas (avg)
 - Optimized: 192,043 gas (avg)
```