### PR TITLE
rename IUniswapV2Callee to IEulerSwapCallee since contract interface …

### DIFF
--- a/src/EulerSwap.sol
+++ b/src/EulerSwap.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.27;
 
-import {IUniswapV2Callee} from "./interfaces/IUniswapV2Callee.sol";
+import {IEulerSwapCallee} from "./interfaces/IEulerSwapCallee.sol";
 
 import {EVCUtil} from "evc/utils/EVCUtil.sol";
 import {IEVC} from "evc/interfaces/IEthereumVaultConnector.sol";
@@ -160,7 +160,7 @@ contract EulerSwap is IEulerSwap, EVCUtil, UniswapHook {
 
         // Invoke callback
 
-        if (data.length > 0) IUniswapV2Callee(to).uniswapV2Call(_msgSender(), amount0Out, amount1Out, data);
+        if (data.length > 0) IEulerSwapCallee(to).eulerSwapCall(_msgSender(), amount0Out, amount1Out, data);
 
         // Deposit all available funds, adjust received amounts downward to collect fees
 

--- a/src/interfaces/IEulerSwap.sol
+++ b/src/interfaces/IEulerSwap.sol
@@ -59,7 +59,7 @@ interface IEulerSwap {
     function getLimits(address tokenIn, address tokenOut) external view returns (uint256, uint256);
 
     /// @notice Optimistically sends the requested amounts of tokens to the `to`
-    /// address, invokes `uniswapV2Call` callback on `to` (if `data` was provided),
+    /// address, invokes `eulerSwapCall` callback on `to` (if `data` was provided),
     /// and then verifies that a sufficient amount of tokens were transferred to
     /// satisfy the swapping curve invariant.
     function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;

--- a/src/interfaces/IEulerSwapCallee.sol
+++ b/src/interfaces/IEulerSwapCallee.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+interface IEulerSwapCallee {
+    function eulerSwapCall(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external;
+}

--- a/src/interfaces/IUniswapV2Callee.sol
+++ b/src/interfaces/IUniswapV2Callee.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.0;
-
-interface IUniswapV2Callee {
-    function uniswapV2Call(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external;
-}

--- a/test/EulerSwapCall.t.sol
+++ b/test/EulerSwapCall.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
-import {IUniswapV2Callee} from "../src/interfaces/IUniswapV2Callee.sol";
+import {IEulerSwapCallee} from "../src/interfaces/IEulerSwapCallee.sol";
 import {IEVault, EulerSwapTestBase, EulerSwap, TestERC20} from "./EulerSwapTestBase.t.sol";
 
-contract UniswapV2CallTest is EulerSwapTestBase {
+contract EulerSwapCallTest is EulerSwapTestBase {
     EulerSwap public eulerSwap;
     SwapCallbackTest swapCallback;
 
@@ -36,7 +36,7 @@ contract UniswapV2CallTest is EulerSwapTestBase {
     }
 }
 
-contract SwapCallbackTest is IUniswapV2Callee {
+contract SwapCallbackTest is IEulerSwapCallee {
     address public callbackSender;
     uint256 public callbackAmount0;
     uint256 public callbackAmount1;
@@ -46,7 +46,7 @@ contract SwapCallbackTest is IUniswapV2Callee {
         eulerSwap.swap(amountIn, amountOut, address(this), data);
     }
 
-    function uniswapV2Call(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external {
+    function eulerSwapCall(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external {
         randomBalance = abi.decode(data, (uint256));
 
         callbackSender = sender;


### PR DESCRIPTION
…isn't exactly identical