### PR TITLE
fix equations of 9 & 21

### DIFF
--- a/docs/whitepaper/main.tex
+++ b/docs/whitepaper/main.tex
@@ -234,7 +234,7 @@ Since real-world markets often operate at variable exchange rates at equilibrium
     \label{eq:weighted-line}
     p_x x + p_y y &= p_x x_0 + p_y y_0, \\
     \label{eq:exponential-form}
-    x^{p_y y_0} y^{p_x x_0} &= x_0^{p_y y_0} y_0^{p_x x_0}.
+    x^{p_x x_0} y^{p_y y_0} &= x_0^{p_x x_0} y_0^{p_y y_0}.
 \end{align}
 
 The CSMM is now a line with a slope parameterised by the ratio of the pricing parameters, whilst the CPMM is now a \textit{weighted} hyperbola. Taking the derivatives of these equations with respect to $x$, we obtain:
@@ -327,7 +327,7 @@ The marginal price anywhere along the curve is given by the derivative, which is
 \begin{align}
     \frac{dy}{dx}
     &=
-    \frac{p_x}{p_y} \left[ -\left( c_x + (1 - c_x) \left( \frac{x_0}{x} \right) \right) - (x_0 - x) (1 - c_x) \left( \frac{x_0}{x} \right)^2 \right] \\ \nonumber
+    \frac{p_x}{p_y} \left[ -\left( c_x + (1 - c_x) \left( \frac{x_0}{x} \right) \right) - (x_0 - x) (1 - c_x) \left( \frac{x_0}{x^2} \right) \right] \\ \nonumber
     &=
     -\frac{p_x}{p_y} \left[ c_x + (1 - c_x) \left( \frac{x_0}{x} \right)^2 \right].
 \end{align}


### PR DESCRIPTION
The EulerSwap white paper contains two specific equations, (9) and (21), that require correction:

1. **Equation (9)** defines a weighted hyperbola in the form of a constant product market maker (CPMM). Currently, the equation assigns weights of \( P_y \cdot y_0 \) and \( P_x \cdot x_0 \) to \( x \) and \( y \), respectively. These weights should be reversed: \( x \) should have a weight of \( P_x \cdot x_0 \), and \( y \) should have a weight of \( P_y \cdot y_0 \).

2. **Equation (21)** calculates the marginal price along the curve, with the final inner element currently expressed as:
   \[
   (x_0 - x) (1 - c_x) \left( \frac{x_0}{x} \right)^2
   \]

   This expression should be corrected to:
   \[
   (x_0 - x) (1 - c_x) \left( \frac{x_0}{x^2} \right)
   \]