### PR TITLE
 Fix duplicate EulerSwap import in HookSwaps tests

### DIFF
--- a/test/HookSwaps.t.sol
+++ b/test/HookSwaps.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.24;
 
 import {EulerSwapTestBase, EulerSwap, EulerSwapPeriphery, IEulerSwap} from "./EulerSwapTestBase.t.sol";
 import {TestERC20} from "evk-test/unit/evault/EVaultTestBase.t.sol";
-import {EulerSwap} from "../src/EulerSwap.sol";
 import {UniswapHook} from "../src/UniswapHook.sol";
 
 import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";


### PR DESCRIPTION
This PR removes a duplicate EulerSwap import in HookSwaps.t.sol. The file already imports EulerSwap via EulerSwapTestBase.t.sol, so the extra direct import causes a Solidity duplicate identifier error. Keeping a single import restores clean compilation of the test file without changing behavior.